### PR TITLE
Fixed description of synergy filters

### DIFF
--- a/doc/SYNERGY_CALCULATION.md
+++ b/doc/SYNERGY_CALCULATION.md
@@ -232,7 +232,7 @@ that have a non-standard filter:
 If any of the [`unifiedTypeSynergies`](#unifying-subtype-synergies) appear in `synergyFilters`, the generator applies
 that filter to its synergy values. The standard filter `min -1`, which removes the highest number from the synergies, is
 applied to categories that don't appear in `synergyFilters`. In `filterForTypeCategory()` you see that for 'max' filters
-the values get sorted ascending, and for `min` filters descending. Then it takes the first **n** values for filters
+the values get sorted descending, and for `min` filters ascending. Then it takes the first **n** values for filters
 with `filterValue` **n**. It removes **n** values from the end for filters with `filterValue` **-n**.
 
 The only category from the example that appears in `synergyFilters` is `botw`, so the `min 1` filter is applied to its


### PR DESCRIPTION
Noticed this when reading up on synergies while rewriting my synergy calculations for stats, I kept getting bad values when following what the readme says.

The stated sorting of the synergy list for filtering was mixed up between max and min filters, see [line 145 in synergyCalculator.ts](https://github.com/ootbingo/oot-bingo-generator/blob/ff87b354b311e391cd8d44dcfa0a7ab7468bc252/src/synergyCalculator.ts#L145)